### PR TITLE
Add VeRL-Omni to Libraries and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,21 @@ We structure this collection along a trajectory of visual RL. This chart ugroups
 
 
 ## 📚 Table of Contents <!-- omit in toc -->
-Libraries and tools
 
+- [Libraries and tools](#libraries-and-tools)
 - [Benchmarks environments and datasets with Visual RL](#benchmarks-environments-and-datasets-with-visual-rl)
 - [Multi-Modal Large Language Models with RL](#multi-modal-large-language-models-with-rl)
 - [Visual Generation with RL](#visual-generation-with-rl)
 - [RL for Unified Model](#rl-for-unified-model)
 - [Vision Language Action Models with RL](#vision-language-action-models-with-rl)
 - [Others](#others)
+
+
+### Libraries and tools
+
++ [VeRL-Omni: Easy, Fast, and Stable RL Training for Diffusion and Omni-Modality Models](https://github.com/verl-project/verl-omni) (Apr. 2026)
+  [![Star](https://img.shields.io/github/stars/verl-project/verl-omni.svg?style=social&label=Star)](https://github.com/verl-project/verl-omni)
+  [![Website](https://img.shields.io/badge/Website-9cf)](https://verl-omni.readthedocs.io/en/latest/index.html)
 
 
 ### Benchmarks environments and datasets with Visual RL


### PR DESCRIPTION
## Summary
- Add a proper **Libraries and tools** section (already mentioned in the TOC but previously unlinked/empty).
- Introduce [VeRL-Omni](https://github.com/verl-project/verl-omni), an open-source multimodal RL training framework for diffusion and omni-modality models (built on verl), with GitHub and docs links.

## Why this fits
VeRL-Omni targets RL post-training for diffusion generative models, unified multimodal understanding+generation models, and omni-modality models — closely aligned with this survey repo’s Visual Generation / Unified Model / MLLM scope.

## Test plan
- [x] Confirm no existing open PR already adds VeRL-Omni
- [x] Entry follows the repo’s badge/link formatting convention
- [ ] Maintainer review of section placement under Libraries and tools


Made with [Cursor](https://cursor.com)